### PR TITLE
update Django and fix user logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Blue Button Sample Client Application - Django Version
 This client demonstrates authenticating to the Blue Buttom API and subsequent FHIR API calls.
 It demonstrates the OAuth2 Server Side web application flow where a `client_secret` is used.
 
-This client has been upgraded to Django 1.11.20.
+This client has been upgraded to Django 1.11.22.
 
 ## Status and Contributing
 
@@ -22,13 +22,14 @@ While not required, using `virtualenv` is a good idea.
 The following commands work for Python 3+. Please search `virtualenv` 
 to fine eqivilent commands to install and setup `virtualenv` for Python 2.7.
 
-    python -m venv venv
-    source venv/bin/activate
+    python -m venv env
+    source env/bin/activate
 
 The following command assumes a `virtualenv` was created and activated. 
 If you aren't using `virtualenv`, then you may need to put `sudo` in 
 front of the following `pip` command.
 
+    pip install --upgrade pip
     pip install -r requirements/requirements.txt
     cp bbc/settings/local_sample.py bbc/settings/local.py
     python manage.py migrate --settings bbc.settings.local
@@ -38,7 +39,7 @@ front of the following `pip` command.
 ### Configuring Your Development Application
 
 By default, your application will be set up to use the public OAuth service
-at https://dev.bluebutton.cms.fhirservice.net/. In order to use this version of
+at https://sandbox.bluebutton.cms.gov/. In order to use this version of
 the service, you'll need to request an account on that site. So select Account ->
 "Request an Invite," fill out the form, setting user type to "Developer," and
 we'll get back to you as soon as possible.
@@ -82,7 +83,7 @@ tell the oauthlib to operate in an insecure mode like so.
 
 ## Running the Tests
 
-To run the tests against https://dev.bluebutton.cms.fhirservice.net use:
+To run the tests against https://sandbox.bluebutton.cms.gov use:
 
     python manage.py test --settings=bbc.settings.test
 

--- a/bbc/apps/accounts/views.py
+++ b/bbc/apps/accounts/views.py
@@ -14,6 +14,19 @@ __author__ = "Alan Viars"
 
 @login_required
 def my_logout(request):
+    # applying fix for non-admin user
+    removed = False
+    u = request.user
+    u_n = request.user.username
+
+    if not u.is_staff:
+        # remove this non-staff user account on logout
+        u.delete()
+        removed = True
+
     logout(request)
-    messages.success(request, _("You have been logged out."))
+    if removed:
+        messages.success(request, _("Temporary account removed for %s." % u_n))
+    else:
+        messages.success(request, _("You have been logged out."))
     return HttpResponseRedirect(reverse('home'))

--- a/bbc/apps/home/templates/authenticated-home.html
+++ b/bbc/apps/home/templates/authenticated-home.html
@@ -7,7 +7,7 @@
 
     <div class="row">
       <div class="col-lg-12">
-         <h1 class="page-header">Hello {{user|capfirst}}</h1>
+         <h1 class="page-header">Hello {{user.first_name|capfirst}} {{ user.last_name|capfirst }} {{ user.username }}</h1>
       </div>
     </div>
 

--- a/bbc/requirements/requirements.in
+++ b/bbc/requirements/requirements.in
@@ -1,4 +1,4 @@
-Django>=1.11.20
+Django>=1.11.22
 django-bootstrap-form
 django-localflavor
 python-social-auth

--- a/bbc/requirements/requirements.txt
+++ b/bbc/requirements/requirements.txt
@@ -2,7 +2,7 @@ beautifulsoup4==4.6.0
 certifi==2017.7.27.1
 chardet==3.0.4
 defusedxml==0.5.0
-Django==1.11.20
+Django==1.11.22
 django-bootstrap-form==3.3
 django-localflavor==1.5.2
 django-settings-export==1.2.1

--- a/bbc/templates/include/top-nav.html
+++ b/bbc/templates/include/top-nav.html
@@ -17,7 +17,7 @@
 
             {% if user.is_authenticated %}
              <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ user }} <b class="caret"></b></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ user.first_name }} {{ user.last_name }} {{ user }}<b class="caret"></b></a>
               <ul class="dropdown-menu">
                 <li><a href="/accounts/logout">Logout</a></li>
               </ul>


### PR DESCRIPTION
Updated Django to 1.11.22 to address security fix.
Also updated client app to remove user account if not a staff account when logged out.
If this is not done the top nav and user name do not match the account that is pulled in from the blue button api.
Also updated README.md and tested deployment from Readme file.